### PR TITLE
Add unit tests for ActivityMapper

### DIFF
--- a/src/ApplicationToActivityMapper.sln
+++ b/src/ApplicationToActivityMapper.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 15.0.28010.2016
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ApplicationToActivityMapper", "ApplicationToActivityMapper\ApplicationToActivityMapper.csproj", "{0D27BD96-33FB-43D8-A4AB-0CC45B7ADF42}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ApplicationToActivityMapperTests", "ApplicationToActivityMapperTests\ApplicationToActivityMapperTests.csproj", "{04D4232B-50D5-437E-A1C8-53004C0DE338}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{0D27BD96-33FB-43D8-A4AB-0CC45B7ADF42}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0D27BD96-33FB-43D8-A4AB-0CC45B7ADF42}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0D27BD96-33FB-43D8-A4AB-0CC45B7ADF42}.Release|Any CPU.Build.0 = Release|Any CPU
+		{04D4232B-50D5-437E-A1C8-53004C0DE338}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{04D4232B-50D5-437E-A1C8-53004C0DE338}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{04D4232B-50D5-437E-A1C8-53004C0DE338}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{04D4232B-50D5-437E-A1C8-53004C0DE338}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/ApplicationToActivityMapper/ActivityMapper.cs
+++ b/src/ApplicationToActivityMapper/ActivityMapper.cs
@@ -78,9 +78,14 @@ namespace ApplicationToActivityMapper
                 windowName = windowName?.ToLower();
                 processName = processName?.ToLower();
 
+                // There should always be a process name. Ignore window title if process name is null.
+                if (processName == null)
+                {
+                    return ActivityCategory.Unknown;
+                }
 
                 // all IDLE, will later manually check with more info to find meetings, breaks, etc.
-                if (processName != null && processName.Equals("idle"))
+                if (processName.Equals("idle"))
                 {
                     return ActivityCategory.Idle;
                 }

--- a/src/ApplicationToActivityMapperTests/ActivityMapperTest.cs
+++ b/src/ApplicationToActivityMapperTests/ActivityMapperTest.cs
@@ -1,0 +1,74 @@
+using ApplicationToActivityMapper;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
+
+namespace ApplicationToActivityMapperTests
+{
+    [TestClass]
+    public class ActivityMapperTest
+    {
+
+        private static IEnumerable<object[]> Data
+        {
+            // ReSharper disable once UnusedMember.Local
+            get
+            {
+                yield return new object[] { ActivityCategory.Unknown, "", "" };
+                yield return new object[] { ActivityCategory.Unknown, null, null };
+                yield return new object[] { ActivityCategory.Unknown, null, "___" };
+                yield return new object[] { ActivityCategory.Unknown, "___", null };
+                yield return new object[] { ActivityCategory.Unknown, "___", "___" };
+
+                yield return new object[] { ActivityCategory.Idle, "idle", null };
+                yield return new object[] { ActivityCategory.Idle, "idle", "Not Idle" };
+
+                yield return new object[] { ActivityCategory.Planning, "someting", "Task View" };
+                yield return new object[] { ActivityCategory.Planning, "trello", "Trello" };
+
+                yield return new object[] { ActivityCategory.Other, "taskmgr", "Task Manager" };
+
+                yield return new object[] { ActivityCategory.Email, "mail", "mail" };
+
+                yield return new object[] { ActivityCategory.DevCode, "vim", ".ts" };
+                yield return new object[] { ActivityCategory.DevCode, "vim", "___" };
+                yield return new object[] { ActivityCategory.DevCode, "rstudio", "" };
+                yield return new object[] { ActivityCategory.DevCode, "firefox", ".ts" };
+
+                yield return new object[] { ActivityCategory.DevDebug, "debug", "debug" };
+
+                yield return new object[] { ActivityCategory.DevReview, "gerrit", "code review" };
+
+                yield return new object[] { ActivityCategory.DevVc, "diff", "diff" };
+
+                yield return new object[] { ActivityCategory.ReadWriteDocument, "vim", "" };
+                yield return new object[] { ActivityCategory.ReadWriteDocument, "vim", "new file" };
+                yield return new object[] { ActivityCategory.ReadWriteDocument, "vim", "vim" };
+                //yield return new object[] { ActivityCategory.ReadWriteDocument, "snagiteditor", "" }; // Broken due to "git"
+                yield return new object[] { ActivityCategory.ReadWriteDocument, "confluence", "" };
+
+                yield return new object[] { ActivityCategory.InstantMessaging, "messenger", "messenger" };
+                yield return new object[] { ActivityCategory.InstantMessaging, "firefox", "messenger" };
+
+                yield return new object[] { ActivityCategory.WorkRelatedBrowsing, "firefox", "linkedin" };
+                yield return new object[] { ActivityCategory.WorkRelatedBrowsing, "firefox", "" };
+
+                yield return new object[] { ActivityCategory.WorkUnrelatedBrowsing, "firefox", "facebook" };
+
+                yield return new object[] { ActivityCategory.FileNavigationInExplorer, "explorer", "" };
+
+                yield return new object[] { ActivityCategory.OtherRdp, "vmware", "" };
+
+                yield return new object[] { ActivityCategory.Gaming, "battle.net", "" };
+
+                yield return new object[] { ActivityCategory.Other, "searchui", "" };
+            }
+        }
+
+        [DataTestMethod]
+        [DynamicData(nameof(Data))]
+        public void TestMap(ActivityCategory category, string processName, string windowTitle)
+        {
+            Assert.AreEqual(category, new ActivityMapper().Map(processName, windowTitle));
+        }
+    }
+}

--- a/src/ApplicationToActivityMapperTests/ApplicationToActivityMapperTests.csproj
+++ b/src/ApplicationToActivityMapperTests/ApplicationToActivityMapperTests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="1.2.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.2.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ApplicationToActivityMapper\ApplicationToActivityMapper.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Adds unit tests with ~99% test coverage.

@casaout it might make sense to generate some input combinations and check if the result is actually correct.
For example `("snagiteditor", "Snagit Editor") => DevVc` (instead of `ReadWriteDocument`) because it contains `"git"` which is checked before.

@RaphaelRo would you mind reviewing as well?